### PR TITLE
link fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Announcements and events associated with the [W3C Credentials CG](https://w3c-cc
 
 Weekly commmunity group call on Tuesdays: Detais:
 
-- Meeting Page: https://w3c-ccg.github.io/
-- Archives: https://github.com/w3c-ccg/meetings
-- Connection Information: https://w3c-ccg.github.io/connecting.html
+- Meeting Page: [https://w3c-ccg.github.io/](https://w3c-ccg.github.io/)
+- Archives: [https://github.com/w3c-ccg/meetings](https://github.com/w3c-ccg/meetings)
+- Connection Information: [https://w3c-ccg.github.io/connecting.html](https://w3c-ccg.github.io/connecting.html)
 - Time: Noon–1 pm ET (conversion to other timezones varies with the calendar; check yours [here](https://www.timeanddate.com/worldclock/converter.html))
 
 
@@ -24,7 +24,7 @@ Weekly commmunity group call on Tuesdays: Detais:
 
 Verifiable Credentials for Education task force calls on Mondays. See details:
 
-- Meeting page: https://w3c-ccg.github.io/vc-ed/
+- Meeting page: [https://w3c-ccg.github.io/vc-ed/](https://w3c-ccg.github.io/vc-ed/)
 - Time 8–9 am PT (conversion to other timezones varies with the calendar; check yours [here](https://www.timeanddate.com/worldclock/converter.html))
 
 
@@ -32,9 +32,10 @@ Verifiable Credentials for Education task force calls on Mondays. See details:
 
 Dedicated DID Resolution calls on Mondays. Details:
 
-- Meeting page: https://docs.google.com/document/d/1qYBaXQMUoB86Alquu7WBtWOxsS8SMhp1fioYKEGCabE/
+- Meeting page: [https://docs.google.com/document/d/1qYBaXQMUoB86Alquu7WBtWOxsS8SMhp1fioYKEGCabE/](https://docs.google.com/document/d/1qYBaXQMUoB86Alquu7WBtWOxsS8SMhp1fioYKEGCabE/)
 - Zoom room: [https://zoom.us/j/7077077007](https://zoom.us/j/7077077007)
 - Time: 4–5 pm ET (conversion to other timezones varies with the calendar; check yours [here](https://www.timeanddate.com/worldclock/converter.html))
+
 
 ### Confidential Storage calls on Thursdays 1-2pm PT / 4-5pm ET
 


### PR DESCRIPTION
that is, making all links live on github.io (which doesn't auto-liven URLs within markdown, unlike github itself)